### PR TITLE
Get right Android SDK Path on Linux, Mac and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Android WiFi ADB - IntelliJ/Android Studio Plugin [![Build Status](https://travi
 
 **Android WiFI ADB plugin adds a button ![Android WiFi ADB Button][5] to your IntelliJ/Android Studio Toolbar** to connect your device to your computer over WiFi.  
 
-*This plugin only works when you are working with an Android Project configured on your IntelliJ/Android Studio.*
+*To use this plugin the project opened in your IntelliJ/Android Studio has to be an Android project configured with the Android SDK.*
 
 Screenshots
 -----------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Android WiFi ADB - IntelliJ/Android Studio Plugin [![Build Status](https://travi
 
 **Android WiFI ADB plugin adds a button ![Android WiFi ADB Button][5] to your IntelliJ/Android Studio Toolbar** to connect your device to your computer over WiFi.  
 
-*To use this plugin you have to declare the ``ANDROID_HOME`` env var properly.*
+*This plugin only works when you are working with an Android Project configured on your IntelliJ/Android Studio.*
 
 Screenshots
 -----------

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ intellij {
   version '14.1.5'
   pluginName 'AndroidWiFiADB'
   plugins 'android'
+  updateSinceUntilBuild false
 }
 
 dependencies {

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/AndroidWiFiADB.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/AndroidWiFiADB.java
@@ -56,7 +56,7 @@ public class AndroidWiFiADB {
     return adb.isInstalled();
   }
 
-    public void updateProject(Project project) {
-        this.adb.updateProject(project);
-    }
+  public void updateProject(Project project) {
+    this.adb.updateProject(project);
+  }
 }

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/AndroidWiFiADB.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/AndroidWiFiADB.java
@@ -26,7 +26,7 @@ public class AndroidWiFiADB {
   private final ADB adb;
   private final View view;
 
-    public AndroidWiFiADB(ADB adb, View view) {
+  public AndroidWiFiADB(ADB adb, View view) {
     this.adb = adb;
     this.view = view;
   }

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/AndroidWiFiADB.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/AndroidWiFiADB.java
@@ -17,6 +17,8 @@
 package com.github.pedrovgs.androidwifiadb;
 
 import com.github.pedrovgs.androidwifiadb.adb.ADB;
+import com.intellij.openapi.project.Project;
+
 import java.util.List;
 
 public class AndroidWiFiADB {
@@ -24,7 +26,7 @@ public class AndroidWiFiADB {
   private final ADB adb;
   private final View view;
 
-  public AndroidWiFiADB(ADB adb, View view) {
+    public AndroidWiFiADB(ADB adb, View view) {
     this.adb = adb;
     this.view = view;
   }
@@ -53,4 +55,8 @@ public class AndroidWiFiADB {
   private boolean isADBInstalled() {
     return adb.isInstalled();
   }
+
+    public void updateProject(Project project) {
+        this.adb.updateProject(project);
+    }
 }

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
@@ -73,7 +73,7 @@ public class AndroidWiFiADBAction extends AnAction implements View {
 
   @Override public void showADBNotInstalledNotification() {
     showNotification(ANDROID_WIFI_ADB_TITLE,
-        "'adb' command not found. Review your Android SDK installation.", NotificationType.ERROR);
+        "Android SDK not found. Please, review your project configuration and be sure that you are working on an Android project.", NotificationType.ERROR);
   }
 
   private void showNotification(final String title, final String message,

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
@@ -45,12 +45,13 @@ public class AndroidWiFiADBAction extends AnAction implements View {
     this.androidWifiADB = new AndroidWiFiADB(adb, this);
   }
 
-  public void actionPerformed(AnActionEvent event) {
-    ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
-      public void run() {
-        androidWifiADB.connectDevices();
-      }
-    });
+  public void actionPerformed(final AnActionEvent event) {
+      this.androidWifiADB.updateProject(event.getProject());
+      ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
+          public void run() {
+              androidWifiADB.connectDevices();
+          }
+      });
   }
 
   @Override public void showNoConnectedDevicesNotification() {

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
@@ -73,7 +73,8 @@ public class AndroidWiFiADBAction extends AnAction implements View {
 
   @Override public void showADBNotInstalledNotification() {
     showNotification(ANDROID_WIFI_ADB_TITLE,
-        "Android SDK not found. Please, review your project configuration and be sure that you are working on an Android project.", NotificationType.ERROR);
+        "Android SDK not found. Please, review your project configuration and be sure that you are working on an "
+                + "Android project.", NotificationType.ERROR);
   }
 
   private void showNotification(final String title, final String message,

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/action/AndroidWiFiADBAction.java
@@ -46,12 +46,12 @@ public class AndroidWiFiADBAction extends AnAction implements View {
   }
 
   public void actionPerformed(final AnActionEvent event) {
-      this.androidWifiADB.updateProject(event.getProject());
-      ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
-          public void run() {
-              androidWifiADB.connectDevices();
-          }
-      });
+    this.androidWifiADB.updateProject(event.getProject());
+    ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
+      public void run() {
+        androidWifiADB.connectDevices();
+      }
+    });
   }
 
   @Override public void showNoConnectedDevicesNotification() {

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/adb/ADB.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/adb/ADB.java
@@ -17,18 +17,17 @@
 package com.github.pedrovgs.androidwifiadb.adb;
 
 import com.github.pedrovgs.androidwifiadb.Device;
-import com.intellij.util.EnvironmentUtil;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.android.sdk.AndroidSdkUtils;
+
 import java.io.File;
 import java.util.List;
 
 public class ADB {
 
-  private static final String ANDROID_ENV_VAR_NAME = "ANDROID_HOME";
-  private static final String ADB_RELATIVE_PATH =
-      File.separator + "platform-tools" + File.separator + "adb";
-
   private final CommandLine commandLine;
   private final ADBParser adbParser;
+  private Project project;
 
   public ADB(CommandLine commandLine, ADBParser adbParser) {
     this.commandLine = commandLine;
@@ -36,8 +35,7 @@ public class ADB {
   }
 
   public boolean isInstalled() {
-    String versionCommand = getCommand("version");
-    return !commandLine.executeCommand(versionCommand).isEmpty();
+    return AndroidSdkUtils.isAndroidSdkAvailable();
   }
 
   public List<Device> getDevicesConnectedByUSB() {
@@ -78,19 +76,21 @@ public class ADB {
     return connectOutput.contains("connected");
   }
 
-  private String getAdbPath() {
-    String androidSdkPath = EnvironmentUtil.getValue(ANDROID_ENV_VAR_NAME);
-    if (androidSdkPath == null || androidSdkPath.isEmpty()) {
-      return "";
+
+  private String getAdbPath(Project project) {
+    String adbPath = "";
+    File adbFile = AndroidSdkUtils.getAdb(project);
+    if (adbFile != null) {
+      adbPath = adbFile.getAbsolutePath();
     }
-    String adbPath = ADB_RELATIVE_PATH;
-    String separator =
-        androidSdkPath.substring(androidSdkPath.length() - 1).equals(File.separator) ? ""
-            : File.separator;
-    return androidSdkPath + separator + adbPath;
+    return adbPath;
   }
 
   private String getCommand(String command) {
-    return getAdbPath() + " " + command;
+    return getAdbPath(project) + " " + command;
+  }
+
+  public void updateProject(Project project) {
+    this.project = project;
   }
 }

--- a/src/main/java/com/github/pedrovgs/androidwifiadb/adb/ADB.java
+++ b/src/main/java/com/github/pedrovgs/androidwifiadb/adb/ADB.java
@@ -77,7 +77,7 @@ public class ADB {
   }
 
 
-  private String getAdbPath(Project project) {
+  private String getAdbPath() {
     String adbPath = "";
     File adbFile = AndroidSdkUtils.getAdb(project);
     if (adbFile != null) {
@@ -87,7 +87,7 @@ public class ADB {
   }
 
   private String getCommand(String command) {
-    return getAdbPath(project) + " " + command;
+    return getAdbPath() + " " + command;
   }
 
   public void updateProject(Project project) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
   <idea-version since-build="131"/>
 
   <extensions defaultExtensionNs="com.intellij">
-      <defaultProjectTypeProvider type="Android"/>
+  <defaultProjectTypeProvider type="Android"/>
   </extensions>
 
   <application-components>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
   <idea-version since-build="131"/>
 
   <extensions defaultExtensionNs="com.intellij">
-
+      <defaultProjectTypeProvider type="Android"/>
   </extensions>
 
   <application-components>
@@ -32,6 +32,8 @@
 
   </project-components>
 
+  <depends>org.jetbrains.android</depends>
+
   <actions>
 
     <action id="AndroidWiFiADB"
@@ -39,6 +41,7 @@
         text="AndroidWiFiADB"
         description="Connects your Android devices to your computer over TCP just with one click."
         icon="/icons/androidWiFiADBIcon.png"
+        project-type="Android"
         >
       <add-to-group group-id="MainToolBar" anchor="last"/>
     </action>


### PR DESCRIPTION
Use AndroidSdkUtils to obtain Android SDK Path instead to ask to system about its environment variables
