### PR TITLE
Show plugin action in NavBarToolBar

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,6 +59,7 @@
         project-type="Android"
         >
       <add-to-group group-id="MainToolBar" anchor="last"/>
+      <add-to-group group-id="NavBarToolBar" anchor="first"/>
     </action>
 
   </actions>


### PR DESCRIPTION
If View->Toolbar is disabled, plugin action is shown in NavBarToolBar (first item).
If View->Toolbar is enabled, plugin action is shown in MainToolBar (last item).

**Android Studio test:**
NavBarToolBar
<img width="726" alt="screen shot 2016-07-19 at 2 26 11 pm" src="https://cloud.githubusercontent.com/assets/3036347/16948645/90165664-4dbe-11e6-9916-00c404a8792f.png">
MainToolBar
<img width="1071" alt="screen shot 2016-07-19 at 2 26 27 pm" src="https://cloud.githubusercontent.com/assets/3036347/16948644/901636d4-4dbe-11e6-9dfd-8c60cb60b439.png">

**Intellij Idea test:**
NavBarToolBar
<img width="293" alt="screen shot 2016-07-19 at 2 30 12 pm" src="https://cloud.githubusercontent.com/assets/3036347/16948685/c058e7f6-4dbe-11e6-839a-1a0086c0d01f.png">
MainToolBar
<img width="681" alt="screen shot 2016-07-19 at 2 30 29 pm" src="https://cloud.githubusercontent.com/assets/3036347/16948684/c058bb50-4dbe-11e6-8ae7-d3273953aa16.png">

Closes https://github.com/pedrovgs/AndroidWiFiADB/issues/32
